### PR TITLE
Use hasOwnProperty to properly detect whether a value is "expected"

### DIFF
--- a/src/StringMappee.ts
+++ b/src/StringMappee.ts
@@ -29,9 +29,9 @@ export class StringMappee<S extends string> {
      * @returns The mapped value from the mapper.
      */
     public with<R>(mapper: StringMapper<S, R>): R {
-        if (this.value in mapper) {
+        if (mapper.hasOwnProperty(this.value)) {
             return (mapper as StringMapperCore<S, R>)[this.value];
-        } else if ("handleUnexpected" in mapper) {
+        } else if (mapper.hasOwnProperty("handleUnexpected")) {
             return mapper.handleUnexpected!;
         } else {
             throw new Error(`Unexpected value: ${this.value}`);
@@ -64,9 +64,9 @@ export class StringMappeeWithNull<S extends string> {
     public with<R>(mapper: StringMapperWithNull<S, R>): R {
         // This class is used at run time for mapping null values regardless of the compile time
         // type being visited, so we actually have to check if handleNull exists.
-        if ("handleNull" in mapper) {
+        if (mapper.hasOwnProperty("handleNull")) {
             return mapper.handleNull;
-        } else if ("handleUnexpected" in mapper) {
+        } else if (mapper.hasOwnProperty("handleUnexpected")) {
             return mapper.handleUnexpected!;
         } else {
             throw new Error(`Unexpected value: null`);
@@ -99,9 +99,9 @@ export class StringMappeeWithUndefined<S extends string> {
     public with<R>(mapper: StringMapperWithUndefined<S, R>): R {
         // This class is used at run time for mapping undefined values regardless of the compile time
         // type being visited, so we actually have to check if handleUndefined exists.
-        if ("handleUndefined" in mapper) {
+        if (mapper.hasOwnProperty("handleUndefined")) {
             return mapper.handleUndefined;
-        } else if ("handleUnexpected" in mapper) {
+        } else if (mapper.hasOwnProperty("handleUnexpected")) {
             return mapper.handleUnexpected!;
         } else {
             throw new Error(`Unexpected value: undefined`);

--- a/src/StringVisitee.ts
+++ b/src/StringVisitee.ts
@@ -29,9 +29,8 @@ export class StringVisitee<S extends string> {
      * @returns The return value of the visitor method that is called.
      */
     public with<R>(visitor: StringVisitor<S, R>): R {
-        const handler = (visitor as StringVisitorCore<S, R>)[this.value];
-
-        if (handler) {
+        if (visitor.hasOwnProperty(this.value)) {
+            const handler = (visitor as StringVisitorCore<S, R>)[this.value];
             return handler(this.value);
         } else if (visitor.handleUnexpected) {
             return visitor.handleUnexpected(this.value);

--- a/tests/mapString.enum.test.ts
+++ b/tests/mapString.enum.test.ts
@@ -47,6 +47,12 @@ describe("Map String Enum", () => {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
                 result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                result: "Unexpected!"
             }
         ];
 
@@ -115,6 +121,12 @@ describe("Map String Enum", () => {
             {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
+                result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
                 result: "Unexpected!"
             }
         ];
@@ -187,6 +199,12 @@ describe("Map String Enum", () => {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
                 result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                result: "Unexpected!"
             }
         ];
 
@@ -256,6 +274,12 @@ describe("Map String Enum", () => {
             {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
+                result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
                 result: "Unexpected!"
             }
         ];

--- a/tests/mapString.literal.test.ts
+++ b/tests/mapString.literal.test.ts
@@ -43,6 +43,12 @@ describe("Map String Literal", () => {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
                 result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                result: "Unexpected!"
             }
         ];
 
@@ -111,6 +117,12 @@ describe("Map String Literal", () => {
             {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
+                result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
                 result: "Unexpected!"
             }
         ];
@@ -183,6 +195,12 @@ describe("Map String Literal", () => {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
                 result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                result: "Unexpected!"
             }
         ];
 
@@ -252,6 +270,12 @@ describe("Map String Literal", () => {
             {
                 isUnexpected: true,
                 value: "unexpected!" as any as RGB,
+                result: "Unexpected!"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
                 result: "Unexpected!"
             }
         ];

--- a/tests/visitString.enum.test.ts
+++ b/tests/visitString.enum.test.ts
@@ -94,6 +94,13 @@ describe("Visit String Enum", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 
@@ -201,6 +208,13 @@ describe("Visit String Enum", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 
@@ -310,6 +324,13 @@ describe("Visit String Enum", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 
@@ -418,6 +439,13 @@ describe("Visit String Enum", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 

--- a/tests/visitString.literal.test.ts
+++ b/tests/visitString.literal.test.ts
@@ -90,6 +90,13 @@ describe("Visit String Literal", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 
@@ -197,6 +204,13 @@ describe("Visit String Literal", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 
@@ -306,6 +320,13 @@ describe("Visit String Literal", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 
@@ -414,6 +435,13 @@ describe("Visit String Literal", () => {
                 value: "unexpected!" as any as RGB,
                 handlerMock: handlerMockUnexpected,
                 result: "Unexpected! (unexpected!)"
+            },
+            {
+                isUnexpected: true,
+                // matches a standard property name on Object.prototype
+                value: "toString" as any as RGB,
+                handlerMock: handlerMockUnexpected,
+                result: "Unexpected! (toString)"
             }
         ];
 


### PR DESCRIPTION
This fixes a bug where an unexpected value at run time that matches the name of a property on Object.prototype would not be properly detected as an "unexpected" value.  Use hasOwnProperty to test for the key in question, and add unit tests to test the buggy situation.